### PR TITLE
Laravel 5.6 support

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -3,11 +3,11 @@
     "description": "Provides ability to handle Laravel Queues from a fan-out SNS/SQS pattern",
     "type": "laravel-package",
     "require": {
-        "php": ">=7.0",
-        "illuminate/database": "5.5.*",
-        "illuminate/support": "5.5.*",
-        "illuminate/queue": "5.5.*",
-        "aws/aws-sdk-php": "^3.36"
+        "php": "^7.1.3",
+        "illuminate/database": "5.6.*",
+        "illuminate/support": "5.6.*",
+        "illuminate/queue": "5.6.*",
+        "aws/aws-sdk-php": "~3.0"
     },
     "license": "MIT",
     "autoload": {


### PR DESCRIPTION
This commit changes the `composer.json` file to reflect Laravel 5.6 requirements.

Resolves: #3